### PR TITLE
Add python and clang auto formatter workflows

### DIFF
--- a/.github/workflows/clang-formatter.yml
+++ b/.github/workflows/clang-formatter.yml
@@ -1,0 +1,24 @@
+name: Run clang-format Linter
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: DoozyX/clang-format-lint-action@v0.14
+      with:
+        source: '.'
+        exclude: './lib'
+        extensions: 'h,hpp,cpp,c'
+        clangFormatVersion: 14
+        inplace: True
+    - uses: EndBug/add-and-commit@v4
+      with:
+        author_name: Clang Robot
+        author_email: robot@example.com
+        message: 'Committing clang-format changes'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pep8-formatter.yml
+++ b/.github/workflows/pep8-formatter.yml
@@ -1,0 +1,29 @@
+name: Format python code
+on: 
+  push:
+    paths:
+    - '**.py'
+jobs:
+  autoyapf:
+    runs-on: ubuntu-latest
+    name: Python formatter
+    steps:
+      - uses: actions/checkout@master
+        with: 
+          ref: ${{ github.head_ref }}
+      - name: autoyapf
+        id: autoyapf
+        uses: mritunjaysharma394/autoyapf@v2
+        with: 
+          args: --style pep8 --recursive --in-place .
+      - name: Check for modified files
+        id: git-check
+        run: echo ::set-output name=modified::$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi)
+      - name: Push changes
+        if: steps.git-check.outputs.modified == 'true'
+        run: |
+          git config --global user.name 'github-actions'
+          git config --global user.email 'github-actions@github.com'
+          git remote set-url origin https://x-access-token:$${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git commit -am "Automated autoyapf fixes"
+          git push

--- a/image_preprocessing/include/image_preprocessing_cpp/ImagePreprocessing.hpp
+++ b/image_preprocessing/include/image_preprocessing_cpp/ImagePreprocessing.hpp
@@ -1,33 +1,34 @@
-#include <opencv2/opencv.hpp>
-#include <opencv2/imgproc.hpp>
 #include <cv_bridge/cv_bridge.h>
+#include <opencv2/imgproc.hpp>
+#include <opencv2/opencv.hpp>
 
-class ImagePreprocessing
-{
-    private:
-        double clahe_clip_limit{2};
-        double clahe_tile_grid_size{8};
+class ImagePreprocessing {
+private:
+  double clahe_clip_limit{2};
+  double clahe_tile_grid_size{8};
 
-        cv::Mat lab_image, dst; // TODO: Consider moving this into useClahe function
-        cv::Ptr<cv::CLAHE> clahe_;
-        cv::Mat image_clahe; // TODO: Consider moving this into useClahe function
+  cv::Mat lab_image, dst; // TODO: Consider moving this into useClahe function
+  cv::Ptr<cv::CLAHE> clahe_;
+  cv::Mat image_clahe; // TODO: Consider moving this into useClahe function
 
-    public:
-        
-        /**
-         * @brief Construct a new Image Preprocessing object
-         * 
-         * @param init_clahe_cliplimit Number of pixels used to clip the CDF for histogram equalization
-         * @param init_clahe_tilegridsize clahe_grid_size_ x clahe_grid_size_ pixel neighborhood used
-         */
-        ImagePreprocessing(double init_clahe_cliplimit, double init_clahe_tilegridsize);
+public:
+  /**
+   * @brief Construct a new Image Preprocessing object
+   *
+   * @param init_clahe_cliplimit Number of pixels used to clip the CDF for
+   * histogram equalization
+   * @param init_clahe_tilegridsize clahe_grid_size_ x clahe_grid_size_ pixel
+   * neighborhood used
+   */
+  ImagePreprocessing(double init_clahe_cliplimit,
+                     double init_clahe_tilegridsize);
 
-        /**
-         * @brief 
-         * 
-         * @param cv_image_ 
-         * @param clahe_plane Image channel to use CLAHE algorithm on
-         * @return cv::Mat 
-         */
-        cv::Mat doClahe(cv::Mat cv_image_, int clahe_plane);
+  /**
+   * @brief
+   *
+   * @param cv_image_
+   * @param clahe_plane Image channel to use CLAHE algorithm on
+   * @return cv::Mat
+   */
+  cv::Mat doClahe(cv::Mat cv_image_, int clahe_plane);
 };

--- a/image_preprocessing/src/imagePreprocessing.cpp
+++ b/image_preprocessing/src/imagePreprocessing.cpp
@@ -1,23 +1,21 @@
 #include "image_preprocessing_cpp/ImagePreprocessing.hpp"
 
-
-ImagePreprocessing::ImagePreprocessing(double init_clahe_cliplimit, double init_clahe_tilegridsize)
-{
-    clahe_ = cv::createCLAHE();
-    clahe_->setClipLimit(init_clahe_cliplimit);
-    clahe_->setTilesGridSize(cv::Size(init_clahe_tilegridsize, init_clahe_tilegridsize));
+ImagePreprocessing::ImagePreprocessing(double init_clahe_cliplimit,
+                                       double init_clahe_tilegridsize) {
+  clahe_ = cv::createCLAHE();
+  clahe_->setClipLimit(init_clahe_cliplimit);
+  clahe_->setTilesGridSize(
+      cv::Size(init_clahe_tilegridsize, init_clahe_tilegridsize));
 }
 
-cv::Mat ImagePreprocessing::doClahe(cv::Mat cv_image_, int clahe_plane)
-{
-    cv::cvtColor (cv_image_, lab_image, CV_BGR2Lab);
-    std::vector<cv::Mat> lab_planes(3);
-    cv::split(lab_image, lab_planes);
+cv::Mat ImagePreprocessing::doClahe(cv::Mat cv_image_, int clahe_plane) {
+  cv::cvtColor(cv_image_, lab_image, CV_BGR2Lab);
+  std::vector<cv::Mat> lab_planes(3);
+  cv::split(lab_image, lab_planes);
 
-    clahe_->apply(lab_planes[clahe_plane], dst);
-    dst.copyTo(lab_planes[clahe_plane]);
-    cv::merge(lab_planes, lab_image);
-    cv::cvtColor(lab_image, image_clahe, CV_Lab2BGR);
-    return image_clahe;
-
+  clahe_->apply(lab_planes[clahe_plane], dst);
+  dst.copyTo(lab_planes[clahe_plane]);
+  cv::merge(lab_planes, lab_image);
+  cv::cvtColor(lab_image, image_clahe, CV_Lab2BGR);
+  return image_clahe;
 }

--- a/image_preprocessing/src/image_preprocessing_cpp_node.cpp
+++ b/image_preprocessing/src/image_preprocessing_cpp_node.cpp
@@ -1,78 +1,69 @@
-#include <ros/ros.h>
-#include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
-#include <sensor_msgs/image_encodings.h>
-#include <opencv2/imgproc/imgproc.hpp>
+#include <image_transport/image_transport.h>
 #include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+#include <ros/ros.h>
+#include <sensor_msgs/image_encodings.h>
 
 #include "image_preprocessing_cpp/ImagePreprocessing.hpp"
 
-
-class ImagePreprocessingNode
-{
-    ros::NodeHandle nh_;
-    image_transport::ImageTransport it_;
-    image_transport::Subscriber image_sub_;
-    image_transport::Publisher image_pub_;
-    
+class ImagePreprocessingNode {
+  ros::NodeHandle nh_;
+  image_transport::ImageTransport it_;
+  image_transport::Subscriber image_sub_;
+  image_transport::Publisher image_pub_;
 
 private:
-    std::string image_topic{"/zed2/zed_node/rgb/image_rect_color"};
-    std::string clahe_topic{"/image_preprocessing/clahe"};
-    bool useCLAHE{true};
-    double clahe_clip_limit{2};
-    double clahe_tile_grid_size{8};
-    int clahe_plane{0};
+  std::string image_topic{"/zed2/zed_node/rgb/image_rect_color"};
+  std::string clahe_topic{"/image_preprocessing/clahe"};
+  bool useCLAHE{true};
+  double clahe_clip_limit{2};
+  double clahe_tile_grid_size{8};
+  int clahe_plane{0};
 
 public:
-    ImagePreprocessingNode()
-        : it_(nh_)
-        {
-            nh_.getParam("useCLAHE", useCLAHE);
-            nh_.getParam("imageTopic", image_topic);
-            nh_.getParam("claheTopic", clahe_topic);
-            nh_.getParam("claheClipLimit", clahe_clip_limit);
-            nh_.getParam("claheTileGridSize", clahe_tile_grid_size);
-            nh_.getParam("clahePlane", clahe_plane);
+  ImagePreprocessingNode() : it_(nh_) {
+    nh_.getParam("useCLAHE", useCLAHE);
+    nh_.getParam("imageTopic", image_topic);
+    nh_.getParam("claheTopic", clahe_topic);
+    nh_.getParam("claheClipLimit", clahe_clip_limit);
+    nh_.getParam("claheTileGridSize", clahe_tile_grid_size);
+    nh_.getParam("clahePlane", clahe_plane);
 
-            image_sub_ = it_.subscribe(image_topic, 1, &ImagePreprocessingNode::image_callback, this);
-            image_pub_ = it_.advertise(clahe_topic, 1);
-        }
+    image_sub_ = it_.subscribe(image_topic, 1,
+                               &ImagePreprocessingNode::image_callback, this);
+    image_pub_ = it_.advertise(clahe_topic, 1);
+  }
 
-    void image_callback(const sensor_msgs::ImageConstPtr& msg)
-    {
-        ImagePreprocessing image_preprocessing_(clahe_clip_limit, clahe_tile_grid_size);
-        std_msgs::Header header = msg->header;
-        cv::Mat cv_image_;
-        try
-        {
-            cv_image_ = cv_bridge::toCvCopy(msg, "bgr8")->image;
-        }
-        catch(const std::exception& e)
-        {
-            ROS_ERROR("cv_bridge exception: %s", e.what());
-            return;
-        }
-        if(useCLAHE){
-            cv::Mat clahe_image_ = image_preprocessing_.doClahe(cv_image_, clahe_plane);
-            image_pub_.publish(cv_bridge::CvImage(header, "bgr8", clahe_image_).toImageMsg());
-
-        }
+  void image_callback(const sensor_msgs::ImageConstPtr &msg) {
+    ImagePreprocessing image_preprocessing_(clahe_clip_limit,
+                                            clahe_tile_grid_size);
+    std_msgs::Header header = msg->header;
+    cv::Mat cv_image_;
+    try {
+      cv_image_ = cv_bridge::toCvCopy(msg, "bgr8")->image;
+    } catch (const std::exception &e) {
+      ROS_ERROR("cv_bridge exception: %s", e.what());
+      return;
     }
-
-    void image_publish(cv_bridge::CvImagePtr cv_ptr)
-    {
-        image_pub_.publish(cv_ptr -> toImageMsg());
+    if (useCLAHE) {
+      cv::Mat clahe_image_ =
+          image_preprocessing_.doClahe(cv_image_, clahe_plane);
+      image_pub_.publish(
+          cv_bridge::CvImage(header, "bgr8", clahe_image_).toImageMsg());
     }
-    
+  }
+
+  void image_publish(cv_bridge::CvImagePtr cv_ptr) {
+    image_pub_.publish(cv_ptr->toImageMsg());
+  }
 };
 
-int main(int argc, char **argv)
-{   
-    ros::init(argc, argv, "image_preprocessing_cpp_node");
-    ros::NodeHandle nh;
-    ImagePreprocessingNode wrapper;
-    ros::spin();
+int main(int argc, char **argv) {
+  ros::init(argc, argv, "image_preprocessing_cpp_node");
+  ros::NodeHandle nh;
+  ImagePreprocessingNode wrapper;
+  ros::spin();
 
-    return 0;
+  return 0;
 }


### PR DESCRIPTION
Reintegration of work done by David Persson from #104 

- Add automatic pep8 formatter workflow for python files
- Add automatic clang formatter workflow for .cpp, .c, .h, and .hpp files